### PR TITLE
Small fixes

### DIFF
--- a/rplugin/node/vim-be-good/game/base.js
+++ b/rplugin/node/vim-be-good/game/base.js
@@ -119,15 +119,12 @@ class BaseGame {
             const len = yield this.state.buffer.length;
             const expectedLen = this.getTotalLength(lines);
             if (len < expectedLen + 1) {
-                yield this.debugTitle(`Base#Render growing input`);
                 yield this.state.buffer.insert(new Array(expectedLen - len).fill(''), len);
             }
             const toRender = [
                 ...this.instructions,
                 ...lines,
-            ].filter(x => x != null);
-            yield this.nvim.outWrite(JSON.stringify(toRender) + "\n");
-            yield this.debugTitle(`Base#Render rendering`);
+            ];
             yield this.state.buffer.setLines(toRender, {
                 start: 1,
                 end: expectedLen,

--- a/rplugin/node/vim-be-good/game/base.js
+++ b/rplugin/node/vim-be-good/game/base.js
@@ -147,11 +147,10 @@ class BaseGame {
     }
     getMidpoint() {
         // TODO: Brandon? Games should define their own lengths that they need
-        return this.getInstructionOffset() +
-            Math.floor(this.state.lineLength / 2);
+        return Math.floor(this.state.lineLength / 2);
     }
     pickRandomLine() {
-        return ~~(this.getInstructionOffset() + Math.random() * this.state.lineLength);
+        return ~~(Math.random() * this.state.lineLength);
     }
     midPointRandomPoint(high, padding = 0) {
         const midPoint = this.getMidpoint();

--- a/rplugin/node/vim-be-good/game/ci.js
+++ b/rplugin/node/vim-be-good/game/ci.js
@@ -55,7 +55,7 @@ class CiGame extends base_1.BaseGame {
             }
             const jumpPoint = this.midPointRandomPoint(!high);
             yield this.debugTitle(`Choosing jump point ${this.getMidpoint()} - ${jumpPoint}`);
-            yield this.nvim.command(`:${String(jumpPoint)}`);
+            this.state.window.cursor = [jumpPoint, 0];
             this.render(lines);
         });
     }

--- a/rplugin/node/vim-be-good/game/ci.js
+++ b/rplugin/node/vim-be-good/game/ci.js
@@ -32,7 +32,6 @@ class CiGame extends base_1.BaseGame {
         return __awaiter(this, void 0, void 0, function* () {
             const high = Math.random() > 0.5;
             const line = this.midPointRandomPoint(high, 6);
-            yield this.debugTitle(`Choosing line ${this.getMidpoint()} - ${line}`);
             const lines = new Array(this.state.lineLength).fill("");
             this.currentRandomWord = base_1.getRandomWord();
             this.ifStatment = false;
@@ -54,7 +53,6 @@ class CiGame extends base_1.BaseGame {
                 lines[line + 5] = `]`;
             }
             const jumpPoint = this.midPointRandomPoint(!high);
-            yield this.debugTitle(`Choosing jump point ${this.getMidpoint()} - ${jumpPoint}`);
             this.state.window.cursor = [jumpPoint, 0];
             this.render(lines);
         });

--- a/rplugin/node/vim-be-good/game/ci.js
+++ b/rplugin/node/vim-be-good/game/ci.js
@@ -53,7 +53,7 @@ class CiGame extends base_1.BaseGame {
                 lines[line + 5] = `]`;
             }
             const jumpPoint = this.midPointRandomPoint(!high);
-            this.state.window.cursor = [jumpPoint, 0];
+            this.state.window.cursor = [this.getInstructionOffset() + jumpPoint, 0];
             this.render(lines);
         });
     }

--- a/src/game/base.ts
+++ b/src/game/base.ts
@@ -146,12 +146,11 @@ export abstract class BaseGame {
 
     protected getMidpoint(): number {
         // TODO: Brandon? Games should define their own lengths that they need
-        return this.getInstructionOffset() +
-            Math.floor(this.state.lineLength / 2);
+        return Math.floor(this.state.lineLength / 2);
     }
 
     protected pickRandomLine(): number {
-        return ~~(this.getInstructionOffset() + Math.random() * this.state.lineLength);
+        return ~~(Math.random() * this.state.lineLength);
     }
 
     protected midPointRandomPoint(high: boolean, padding = 0) {

--- a/src/game/ci.ts
+++ b/src/game/ci.ts
@@ -49,7 +49,7 @@ export class CiGame extends BaseGame {
         }
 
         const jumpPoint = this.midPointRandomPoint(!high);
-        this.state.window.cursor = [jumpPoint, 0];
+        this.state.window.cursor = [this.getInstructionOffset() + jumpPoint, 0];
         this.render(lines);
     }
 

--- a/src/game/ci.ts
+++ b/src/game/ci.ts
@@ -49,7 +49,7 @@ export class CiGame extends BaseGame {
         }
 
         const jumpPoint = this.midPointRandomPoint(!high);
-        await this.nvim.command(`:${String(jumpPoint)}`);
+        this.state.window.cursor = [jumpPoint, 0];
         this.render(lines);
     }
 


### PR DESCRIPTION
@ThePrimeagen this PR fixes two things:

1. The bug you identified on stream last night where null (technically undefined) was being added to the array of line strings.
2. I updated the code to use the `Window#setCursor` instead of `:${jumpPoint}`.

The first issue was that midpoint calculation included the instruction lines count, but `CiGame#run`'s `lines` does not. That was causing the midpoint to be 10 lines higher than it should have been.

I removed the `undefined` check, and also the `null` check. I don't think either is needed anymore, but I can put the `null` check back in if you think we need it.