### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Plug 'ThePrimeagen/vim-be-good', {'do': './install.sh'}
 ```
 
 Windows 10 - PowerShell
+Requirements:
+[Git for Windows BASH emulation](https://gitforwindows.org/)
+[NodeJs](https://nodejs.org/en/download/)
+
 ```viml
 Plug 'ThePrimeagen/vim-be-good', {'do': '.\install.sh'}
 ```

--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ character's case to complete the round.
 
 1. Use your favorite plugin manager to install!  Only works on Nvim, the one true
 vim.
-
+ 
+Linux
 ```viml
 Plug 'ThePrimeagen/vim-be-good', {'do': './install.sh'}
+```
+
+Windows 10 - PowerShell
+```viml
+Plug 'ThePrimeagen/vim-be-good', {'do': '.\install.sh'}
 ```
 
 2. Then execute `:UpdateRemotePlugins` to finish the installation process.


### PR DESCRIPTION
This quick-fix can build vim-be-good on windows 10.
Requirements:
[
Git for Windows BASH emulation](https://gitforwindows.org/)
[NodeJs](https://nodejs.org/en/download/)

During PlugInstall call on nvim running on PowerShell, it must call git bash and execute the install.sh script.



