### PR TITLE
Add docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ character's case to complete the round.
 Plug 'ThePrimeagen/vim-be-good'
 ```
 
+### Docker
+
+If you would like, you can use docker to run the game. Doing this will
+automatically use the correct version of neovim for you.
+
+```bash
+docker run -it --rm brandoncc/vim-be-good
+```
+
+If you want to make sure you are playing the latest version of the game, use:
+
+```bash
+docker pull brandoncc/vim-be-good && docker run -it --rm brandoncc/vim-be-good
+```
+
 ## Playing the games.
 
 Before doing ANYTHING at all, make sure you are in an empty file. If the file


### PR DESCRIPTION
@ThePrimeagen I thought this was a great idea, so I built it. Anyone can run vim-be-good using:

```bash
docker run -it --rm brandoncc/vim-be-good
```

If they want to make sure they have the latest docker build, they can use:

```bash
docker pull brandoncc/vim-be-good && docker run -it --rm brandoncc/vim-be-good
```

If you would like, I'm happy to transfer ownership of the git and docker repositories to you. Here are the related git repositories:

- https://github.com/brandoncc/docker-vim-be-good
- https://github.com/brandoncc/docker-neovim-master