### PR TITLE
feat: save round statistics to file

### DIFF
--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -6,6 +6,9 @@ local CiRound = require("vim-be-good.games.ci");
 local HjklRound = require("vim-be-good.games.hjkl");
 local WhackAMoleRound = require("vim-be-good.games.whackamole");
 local log = require("vim-be-good.log");
+local statistics = require("vim-be-good.statistics");
+
+Stats = statistics:new()
 
 local endStates = {
     menu = "Menu",
@@ -209,9 +212,18 @@ function GameRunner:endRound(success)
     end
 
     local endTime = GameUtils.getTime()
-    table.insert(self.results.timings, endTime - self.startTime)
+    local totalTime = endTime - self.startTime
+    table.insert(self.results.timings, totalTime)
     table.insert(self.results.games, self.round:name())
 
+    local result = {
+        timestamp = vim.fn.localtime(),
+        roundNum = self.currentRound,
+        difficulty = self.round.difficulty,
+        roundName = self.round:name(),
+        time = totalTime,
+    }
+    Stats:logResult(result)
     log.info("endRound", self.currentRound, self.config.roundCount)
     if self.currentRound >= self.config.roundCount then -- TODO: self.config.roundCount then
         self:endGame()

--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -202,6 +202,7 @@ function GameRunner:checkForWin()
 end
 
 function GameRunner:endRound(success)
+    success = success or false
     local self = self
 
     self.running = false
@@ -221,6 +222,7 @@ function GameRunner:endRound(success)
         roundNum = self.currentRound,
         difficulty = self.round.difficulty,
         roundName = self.round:name(),
+        success = success,
         time = totalTime,
     }
     Stats:logResult(result)

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -23,8 +23,8 @@ end
 function statistics:logResult(result)
     if self.saveStats then
         local fp = io.open(self.file, "a")
-        local str = string.format("%s,%s,%s,%s,%f\n",
-        result.timestamp, result.roundNum, result.difficulty, result.roundName, result.time)
+        local str = string.format("%s,%s,%s,%s,%s,%f\n",
+        result.timestamp, result.roundNum, result.difficulty, result.roundName, result.success, result.time)
         fp:write(str)
         fp:close()
     end

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -1,0 +1,33 @@
+local log = require("vim-be-good.log")
+local default_config =  {
+    plugin = 'VimBeGoodStats',
+
+    save_statistics = vim.g["vim_be_good_save_statistics"] or false,
+
+}
+
+local statistics = {}
+
+function statistics:new(config)
+    config = config or {}
+    config = vim.tbl_deep_extend("force", default_config, config)
+
+    local stats = {
+        file = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin),
+        saveStats = config.save_statistics
+    }
+    self.__index = self
+    return setmetatable(stats, self)
+end
+
+function statistics:logResult(result)
+    if self.saveStats then
+        local fp = io.open(self.file, "a")
+        local str = string.format("%s,%s,%s,%s,%f\n",
+        result.timestamp, result.roundNum, result.difficulty, result.roundName, result.time)
+        fp:write(str)
+        fp:close()
+    end
+end
+
+return statistics


### PR DESCRIPTION
First step into addressing #41 

Right now it saves the following into a stats log file in csv format
* localtime
*current round
* difficulty
* round name
* time to complete round

thoughts?

do we want to go json ?  may be easier once luarocks support is builtin into neovim
do we want to have a rolling log of stats?