### PR TITLE
Refactor some vim.fn to vim.api

### DIFF
--- a/lua/vim-be-good/window.lua
+++ b/lua/vim-be-good/window.lua
@@ -38,7 +38,7 @@ end
 
 function WindowHandler:close()
     if self.winId ~= 0 then
-        vim.fn.nvim_win_close(self.winId, true)
+        vim.api.nvim_win_close(self.winId, true)
     end
 
     self.winId = 0
@@ -54,7 +54,7 @@ end
 
 function WindowHandler:show()
     if self.bufh == 0 then
-        self.bufh = vim.fn.nvim_create_buf(false, true)
+        self.bufh = vim.api.nvim_create_buf(false, true)
         self.buffer = Buffer:new(self.bufh, self)
     end
 


### PR DESCRIPTION
Some of the vim.fn should be refactor to vim.api (most of them are buffer manipulation for this repo) since not only it's the idiomatic way but also recent [neovim version](https://github.com/neovim/neovim/pull/13875) would not support the call to vim.api via vim.fn.