### PR TITLE
Fix "Expected Lua number" error.

### DIFF
--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -303,7 +303,7 @@ function GameRunner:run()
 
     log.info("Setting current line to", cursorLine, cursorCol)
     if cursorLine > 0 then
-        vim.api.nvim_win_set_cursor(self.winId, {cursorLine, cursorCol})
+        vim.api.nvim_win_set_cursor(0, {cursorLine, cursorCol})
     end
 
     self.startTime = GameUtils.getTime()


### PR DESCRIPTION
I had to replace 'self.winId' with 0 to fix the game. As far as I see 'self.winId' is  not used and is always nil. Maybe in previous versions of nvim it was fine to  pass nil into nvim_win_set_cursor but in NVIM v0.8.0 it fails with the error  "game-runner.lua:306: Expected Lua number" and the game stops. That is it  doesn't get to the next round.