### PR TITLE
Avoid DELETE_ME appearing one line from cursor

### DIFF
--- a/lua/vim-be-good/games/relative.lua
+++ b/lua/vim-be-good/games/relative.lua
@@ -63,9 +63,9 @@ function RelativeRound:render()
 
     local cursorIdx
     if goHigh then
-        cursorIdx = math.random(deleteMeIdx + 1, 20)
+        cursorIdx = math.random(deleteMeIdx + 2, 20)
     else
-        cursorIdx = math.random(1, deleteMeIdx - 1)
+        cursorIdx = math.random(1, deleteMeIdx - 2)
     end
 
     lines[deleteMeIdx] = " DELETE_ME"


### PR DESCRIPTION
I would never use relative movements to move one line below or above, since the goal (I think) is to train to use it during high-stakes situations (i.e. writing PHP code) I think it should mimic what you will use relative movements for.