### PR TITLE
new highscore feature

### DIFF
--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -264,7 +264,7 @@ function GameRunner:renderEndGame()
 
     self.ended = true
 
-    Stats:logHighscore( sum/self.config.roundCount , self.results.games[1])
+    Stats:logHighscore(sum/self.config.roundCount , self.results.games[1])
     -- TODO: Make this a bit better especially with random.
     -- print to screen within table 
     table.insert(lines, string.format("%d / %d completed successfully", self.results.successes, self.config.roundCount))

--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -264,7 +264,9 @@ function GameRunner:renderEndGame()
 
     self.ended = true
 
+    Stats:logHighscore( sum/self.config.roundCount , self.results.games[1])
     -- TODO: Make this a bit better especially with random.
+    -- print to screen within table 
     table.insert(lines, string.format("%d / %d completed successfully", self.results.successes, self.config.roundCount))
     table.insert(lines, string.format("Average %.2f", sum / self.config.roundCount))
     table.insert(lines, string.format("Game Type %s", self.results.games[1]))

--- a/lua/vim-be-good/game-utils.lua
+++ b/lua/vim-be-good/game-utils.lua
@@ -103,9 +103,7 @@ local function getTime()
 end
 
 local function getRoundCount(difficulty)
-    --local roundCount = vim.g["vim-be-good-round-count"] or 10
-    -- roundcount for testing to 1 todo reverse
-    local roundCount = 1 --vim.g["vim-be-good-round-count"] or 10
+    local roundCount = vim.g["vim-be-good-round-count"] or 10
 
     if difficulty == "noob" then
         roundCount = 100000

--- a/lua/vim-be-good/game-utils.lua
+++ b/lua/vim-be-good/game-utils.lua
@@ -103,7 +103,9 @@ local function getTime()
 end
 
 local function getRoundCount(difficulty)
-    local roundCount = vim.g["vim-be-good-round-count"] or 10
+    --local roundCount = vim.g["vim-be-good-round-count"] or 10
+    -- roundcount for testing to 1 todo reverse
+    local roundCount = 1 --vim.g["vim-be-good-round-count"] or 10
 
     if difficulty == "noob" then
         roundCount = 100000

--- a/lua/vim-be-good/menu.lua
+++ b/lua/vim-be-good/menu.lua
@@ -152,7 +152,7 @@ function Menu:render()
 
     for idx = 1, #types.games do
         log.info("save highscore ?", vim.g["vim_be_good_save_highscore"])
-        if vim.g["vim_be_good_save_highscore"] then
+        if vim.g["vim_be_good_save_highscore"] or false then
             if types.games[idx] == "random" then
                 table.insert(lines, createMenuItem(types.games[idx], self.game))
             else

--- a/lua/vim-be-good/menu.lua
+++ b/lua/vim-be-good/menu.lua
@@ -151,10 +151,15 @@ function Menu:render()
     end
 
     for idx = 1, #types.games do
-        if types.games[idx] == "random" then
-            table.insert(lines, createMenuItem(types.games[idx], self.game))
+        log.info("save highscore ?", vim.g["vim_be_good_save_highscore"])
+        if vim.g["vim_be_good_save_highscore"] then
+            if types.games[idx] == "random" then
+                table.insert(lines, createMenuItem(types.games[idx], self.game))
+            else
+                table.insert(lines, createMenuItem(types.games[idx], self.game).." \t\t\t | " .. tostring(highscoreTab[types.games[idx]]) .. " sec")
+            end
         else
-            table.insert(lines, createMenuItem(types.games[idx], self.game).." \t\t\t | " .. tostring(highscoreTab[types.games[idx]]) .. " sec")
+            table.insert(lines, createMenuItem(types.games[idx], self.game))
         end
     end
 

--- a/lua/vim-be-good/menu.lua
+++ b/lua/vim-be-good/menu.lua
@@ -2,6 +2,9 @@ local log = require("vim-be-good.log")
 local bind = require("vim-be-good.bind")
 local types = require("vim-be-good.types")
 local createEmpty = require("vim-be-good.game-utils").createEmpty
+local statistics = require("vim-be-good.statistics")
+
+
 
 local Menu = {}
 
@@ -37,7 +40,7 @@ local credits = {
     "https://twitch.tv/ThePrimeagen",
 }
 
-function Menu:new(window, onResults)
+function Menu:new(window, onResults, highscore)
     local menuObj = {
         window = window,
         buffer = window.buffer,
@@ -48,6 +51,8 @@ function Menu:new(window, onResults)
 
         -- relative
         game = types.games[1],
+
+        highscore = highscore,
     }
 
     window.buffer:clear()
@@ -144,7 +149,8 @@ function Menu:render()
     end
 
     for idx = 1, #types.games do
-        table.insert(lines, createMenuItem(types.games[idx], self.game))
+        local highscoreTab = Stats:loadHighscore()
+        table.insert(lines, createMenuItem(types.games[idx], self.game).." \t\t\t | " .. tostring(highscoreTab[types.games[idx]]) .. " sec")
     end
 
     for idx = 1, #difficultyHeader do

--- a/lua/vim-be-good/menu.lua
+++ b/lua/vim-be-good/menu.lua
@@ -143,14 +143,19 @@ end
 function Menu:render()
     self.window.buffer:clearGameLines()
 
+    local highscoreTab = Stats:loadHighscore()
     local lines = { }
+
     for idx = 1, #gameHeader do
         table.insert(lines, gameHeader[idx])
     end
 
     for idx = 1, #types.games do
-        local highscoreTab = Stats:loadHighscore()
-        table.insert(lines, createMenuItem(types.games[idx], self.game).." \t\t\t | " .. tostring(highscoreTab[types.games[idx]]) .. " sec")
+        if types.games[idx] == "random" then
+            table.insert(lines, createMenuItem(types.games[idx], self.game))
+        else
+            table.insert(lines, createMenuItem(types.games[idx], self.game).." \t\t\t | " .. tostring(highscoreTab[types.games[idx]]) .. " sec")
+        end
     end
 
     for idx = 1, #difficultyHeader do

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -20,6 +20,23 @@ function statistics:new(config)
     self.__index = self
     return setmetatable(stats, self)
 end
+function statistics:loadHighscore()
+    local out = io.open(self.file, 'r')
+
+    local fLines = {}
+    for l in out:lines() do
+        table.insert(fLines, l)
+    end
+
+    out:close()
+
+    local t = {}
+    t = {}
+    for k, v in string.gmatch(fLines[1], "(%w+):(%d+%.%d+)") do
+        t[k] = v
+    end
+    return t
+end
 
 function statistics:logHighscore(average,gameType)
     if self.saveStats then
@@ -33,16 +50,12 @@ function statistics:logHighscore(average,gameType)
         out:close()
 
         -- check if new highscore is lower then current highsocre
+        -- \\todo do not overwrite first line
+        -- \\todo check if game is already in highscore if not add it 
         local currHighscore = (string.match(fLines[1],gameType..":".."(%d+%.%d%d)"))
         if tonumber(currHighscore) > average then
             fLines[1] = string.gsub(fLines[1],gameType..":"..currHighscore,gameType..":"..string.format("%.2f",average))
         end
-
-        --local i,j = string.find(fLines[1], gameType..":".."(%d+%.%d%d)")
-        --print(string.sub(fLines[1],i,j))
-        --if currHighscore > average then
-        --    fLines[1] = string.gsub(fLines[1], gameType..":".."%d+%.%d%d" , gameType..":"..string.format("%.2f" , average))
-        --end
 
         local out = io.open(self.file, 'w')
         for _, l in ipairs(fLines) do

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -1,13 +1,14 @@
 local log = require("vim-be-good.log")
+local types = require("vim-be-good.types")
 local default_config =  {
     plugin = 'VimBeGoodStats',
-
-    save_statistics = vim.g["vim_be_good_save_statistics"] or false,
+    -- todo change back
+    -- set to true since i dont know how to enable stats via config 
+    save_statistics = true,
 
 }
 
 local statistics = {}
-
 function statistics:new(config)
     config = config or {}
     config = vim.tbl_deep_extend("force", default_config, config)
@@ -18,6 +19,33 @@ function statistics:new(config)
     }
     self.__index = self
     return setmetatable(stats, self)
+end
+
+function statistics:logHighscore(average,gameType)
+    if self.saveStats then
+        local out = io.open(self.file, 'r')
+
+        local fLines = {}
+        for l in out:lines() do
+            table.insert(fLines, l)
+        end
+
+        out:close()
+
+        -- check if new highscore is lower then current highsocre
+        local i,j = string.find(fLines[1], gameType..":".."(%d+%.%d%d)")
+        print(string.sub(fLines[1],i,j))
+        --if currHighscore > average then
+        --    fLines[1] = string.gsub(fLines[1], gameType..":".."%d+%.%d%d" , gameType..":"..string.format("%.2f" , average))
+        --end
+
+        local out = io.open(self.file, 'w')
+        for _, l in ipairs(fLines) do
+            out:write(l)
+            out:write("\n") -- strage bug that reading lines kills breakline plus concat line + \n also crashes
+        end
+        out:close()
+    end
 end
 
 function statistics:logResult(result)

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -33,8 +33,13 @@ function statistics:logHighscore(average,gameType)
         out:close()
 
         -- check if new highscore is lower then current highsocre
-        local i,j = string.find(fLines[1], gameType..":".."(%d+%.%d%d)")
-        print(string.sub(fLines[1],i,j))
+        local currHighscore = (string.match(fLines[1],gameType..":".."(%d+%.%d%d)"))
+        if tonumber(currHighscore) > average then
+            fLines[1] = string.gsub(fLines[1],gameType..":"..currHighscore,gameType..":"..string.format("%.2f",average))
+        end
+
+        --local i,j = string.find(fLines[1], gameType..":".."(%d+%.%d%d)")
+        --print(string.sub(fLines[1],i,j))
         --if currHighscore > average then
         --    fLines[1] = string.gsub(fLines[1], gameType..":".."%d+%.%d%d" , gameType..":"..string.format("%.2f" , average))
         --end

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -54,9 +54,17 @@ function statistics:logHighscore(average,gameType)
 
         out:close()
 
-        -- check if new highscore is lower then current highsocre
-        -- \\todo do not overwrite first line
-        -- \\todo check if game is already in highscore if not add it 
+        -- TODO if gametype is no in list could cause a crash
+        -- this inits the line if its not present but does not account for new gameTypes
+        if string.find(fLines[1],":") == nil then
+            local highscoreLine = ""
+            for idx = 1, #types.games - 1 do
+                highscoreLine = highscoreLine .. types.games[idx] .. ":10.00,"
+            end
+            table.insert(fLines,1,highscoreLine)
+        end
+        --end
+
         local currHighscore = (string.match(fLines[1],gameType..":".."(%d+%.%d%d)"))
         if tonumber(currHighscore) > average then
             fLines[1] = string.gsub(fLines[1],gameType..":"..currHighscore,gameType..":"..string.format("%.2f",average))
@@ -65,7 +73,6 @@ function statistics:logHighscore(average,gameType)
         local out = io.open(self.file, 'w')
         for _, l in ipairs(fLines) do
             out:write(l.."\n")
-            -- out:write("\n") -- strage when I read the file break line should still be present  
         end
         out:close()
     end

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -29,7 +29,7 @@ function statistics:loadHighscore()
 
     local t = {}
     t = {}
-    for k, v in string.gmatch(fLines[1], "(%w+):(%d+%.%d+)") do
+    for k, v in string.gmatch(fLines[1], "(%w+{*):(%d+%.%d+)") do
         t[k] = v
     end
     return t
@@ -56,8 +56,8 @@ function statistics:logHighscore(average,gameType)
 
         local out = io.open(self.file, 'w')
         for _, l in ipairs(fLines) do
-            out:write(l)
-            out:write("\n") -- strage bug that reading lines kills breakline plus concat line + \n also crashes
+            out:write(l.."\n")
+            -- out:write("\n") -- strage when I read the file break line should still be present  
         end
         out:close()
     end

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -1,38 +1,45 @@
 local log = require("vim-be-good.log")
 local types = require("vim-be-good.types")
+
 local default_config =  {
     plugin = 'VimBeGoodStats',
     save_statistics = vim.g["vim_be_good_save_statistics"] or false,
+    save_highscore = vim.g["vim_be_good_save_highscore"] or false,
 }
 
 local statistics = {}
+
 function statistics:new(config)
     config = config or {}
     config = vim.tbl_deep_extend("force", default_config, config)
 
     local stats = {
         file = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin),
-        saveStats = config.save_statistics
+        saveStats = config.save_statistics,
+        saveHighscore = config.save_highscore
     }
     self.__index = self
     return setmetatable(stats, self)
 end
+
 function statistics:loadHighscore()
-    local out = io.open(self.file, 'r')
+    if self.saveHighscore then
+        local out = io.open(self.file, 'r')
 
-    local fLines = {}
-    for l in out:lines() do
-        table.insert(fLines, l)
+        local fLines = {}
+        for l in out:lines() do
+            table.insert(fLines, l)
+        end
+
+        out:close()
+
+        local highscoreTable = {}
+        highscoreTable= {}
+        for k, v in string.gmatch(fLines[1], "(%w+{*):(%d+%.%d+)") do
+            highscoreTable[k] = v
+        end
+        return highscoreTable
     end
-
-    out:close()
-
-    local t = {}
-    t = {}
-    for k, v in string.gmatch(fLines[1], "(%w+{*):(%d+%.%d+)") do
-        t[k] = v
-    end
-    return t
 end
 
 function statistics:logHighscore(average,gameType)

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -2,10 +2,7 @@ local log = require("vim-be-good.log")
 local types = require("vim-be-good.types")
 local default_config =  {
     plugin = 'VimBeGoodStats',
-    -- todo change back
-    -- set to true since i dont know how to enable stats via config 
-    save_statistics = true,
-
+    save_statistics = vim.g["vim_be_good_save_statistics"] or false,
 }
 
 local statistics = {}

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -23,6 +23,7 @@ function statistics:new(config)
 end
 
 function statistics:loadHighscore()
+    log.info("save highscore?",self.saveHighscore)
     if self.saveHighscore then
         local out = io.open(self.file, 'r')
 
@@ -43,7 +44,7 @@ function statistics:loadHighscore()
 end
 
 function statistics:logHighscore(average,gameType)
-    if self.saveStats then
+    if self.saveHighscore then
         local out = io.open(self.file, 'r')
 
         local fLines = {}

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -23,7 +23,6 @@ function statistics:new(config)
 end
 
 function statistics:loadHighscore()
-    log.info("save highscore?",self.saveHighscore)
     if self.saveHighscore then
         local out = io.open(self.file, 'r')
 
@@ -54,8 +53,7 @@ function statistics:logHighscore(average,gameType)
 
         out:close()
 
-        -- TODO if gametype is no in list could cause a crash
-        -- this inits the line if its not present but does not account for new gameTypes
+        -- this init-line if its not present add init line in statistics tab
         if string.find(fLines[1],":") == nil then
             local highscoreLine = ""
             for idx = 1, #types.games - 1 do
@@ -63,11 +61,15 @@ function statistics:logHighscore(average,gameType)
             end
             table.insert(fLines,1,highscoreLine)
         end
-        --end
 
         local currHighscore = (string.match(fLines[1],gameType..":".."(%d+%.%d%d)"))
-        if tonumber(currHighscore) > average then
-            fLines[1] = string.gsub(fLines[1],gameType..":"..currHighscore,gameType..":"..string.format("%.2f",average))
+        -- if game gets new gametypes then they are not in highscore line this could case a crash
+        if currHighscore == nil then
+            fLines[1] = fLines[1] .. "," .. gameType .. ":" .. string.format("%.2f",average)
+        else
+            if tonumber(currHighscore) > average then
+                fLines[1] = string.gsub(fLines[1],gameType..":"..currHighscore,gameType..":"..string.format("%.2f",average))
+            end
         end
 
         local out = io.open(self.file, 'w')


### PR DESCRIPTION
Dear Mr. Primeagen,

I implemented an additional feature to log highscore values within the statistics file. First line of this file will be used to store best average values for every gameType

Example file entry: 
`ci{:10.00,relative:10.00,hjkl:10.00,whackamole:4.00,words:1.82`
following this pattern
`gameType:\d{2}.\d{2}`

stored values are also visiable within the main menü 

Example:
```
Select a Game (delete from the list to select)
----------------------------------------------
[x] words 			 | 1.82 sec
[ ] ci{ 			         | 10.00 sec
[ ] relative 			 | 10.00 sec
[ ] hjkl 			         | 10.00 sec
[ ] whackamole 		 | 4.00 sec
[ ] random
```

Feature can be enable or disable via VIMRC with 
`vim.g.vim_be_good_save_highscore = true
`

Kind regards,
Uwe
