### PR TITLE
feat: save game statistics to file

### DIFF
--- a/lua/vim-be-good/game-runner.lua
+++ b/lua/vim-be-good/game-runner.lua
@@ -286,6 +286,34 @@ end
 function GameRunner:endGame()
     local lines = self:renderEndGame()
     self.state = states.gameEnd
+
+    local sum = 0
+    for idx = 1, #self.results.timings do
+        sum = sum + self.results.timings[idx]
+    end
+    local mean = sum / self.config.roundCount
+
+    local tmp = 0
+    for idx = 1, #self.results.timings do
+            tmp = tmp + (self.results.timings[idx] - mean)^2
+    end
+    local sstddev = (1/(self.config.roundCount - 1)*tmp)^(1/2)
+
+    table.sort(self.results.timings)
+    local min = self.results.timings[1]
+    local max = self.results.timings[#self.results.timings]
+
+    local result = {
+        timestamp = vim.fn.localtime(),
+        gameName = self.round:name(),
+        difficulty = self.round.difficulty,
+        successRate = self.results.successes / self.config.roundCount,
+        meanTime = mean,
+	sstdDevTime = sstddev,
+	minTime = min,
+	maxTime = max
+    }
+    Stats:logGameResult(result)
     self.window.buffer:setInstructions({})
     self.window.buffer:render(lines)
 end

--- a/lua/vim-be-good/statistics.lua
+++ b/lua/vim-be-good/statistics.lua
@@ -13,7 +13,8 @@ function statistics:new(config)
     config = vim.tbl_deep_extend("force", default_config, config)
 
     local stats = {
-        file = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin),
+        file = string.format('%s/%s_%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin, "rounds"),
+        gameLogFile = string.format('%s/%s_%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin, "games"),
         saveStats = config.save_statistics
     }
     self.__index = self
@@ -30,4 +31,13 @@ function statistics:logResult(result)
     end
 end
 
+function statistics:logGameResult(result)
+    if self.saveStats then
+        local fp = io.open(self.gameLogFile, "a")
+        local str = string.format("%s,%s,%s,%f,%f,%f,%f,%f\n",
+        result.timestamp, result.gameName, result.difficulty, result.successRate, result.meanTime, result.sstdDevTime, result.minTime, result.maxTime)
+        fp:write(str)
+        fp:close()
+    end
+end
 return statistics


### PR DESCRIPTION
Built upon work of @polarmutex and #103 but on a per-game basis.

Combine that with a bit of gnuplot magic, one can track ones progress visually after creating a symlink to the actual logfile eg.
```
ln -s ~/.local/share/nvim/VimBeGoodStats_games.log stats.log
```
and running gnuplot with something like:
```
set datafile separator ','

myTimeFmt = "%Y-%m-%d %H:%M:%S"
set timefmt myTimeFmt

set title "VimBeGood Stats"
set grid
set tics nomirror
set border 11
set xdata time
set xlabel 'Date/Time'
set xtics format myTimeFmt
set xtics rotate
set ylabel 'Time in Seconds'
set yrange [0:]
set y2label 'Success rate'
set y2range [0:1.1]
set y2tics

plot '<(sed "/words/!d" stats.log)' using (strftime(myTimeFmt, $1)):5:7:8 with errorlines title "words" lt rgb "red", \
	'' using (strftime(myTimeFmt, $1)):4 axis x1y2 with linespoints title "words success rate" lt rgb "red", \
	'<(sed "/ci{/!d" stats.log)' using (strftime(myTimeFmt, $1)):5:7:8 with errorlines title "ci{" lt rgb "blue", \
	'' using (strftime(myTimeFmt, $1)):4 axis x1y2 with linespoints title "ci{ success rate" lt rgb "blue", \
	'<(sed "/relative/!d" stats.log)' using (strftime(myTimeFmt, $1)):5:7:8 with errorlines title "relative" lt rgb "green", \
	'' using (strftime(myTimeFmt, $1)):4 axis x1y2 with linespoints title "relative success rate" lt rgb "green", \
	'<(sed "/hjkl/!d" stats.log)' using (strftime(myTimeFmt, $1)):5:7:8 with errorlines title "hjkl" lt rgb "grey", \
	'' using (strftime(myTimeFmt, $1)):4 axis x1y2 with linespoints title "hjkl success rate" lt rgb "grey", \
	'<(sed "/whackamole/!d" stats.log)' using (strftime(myTimeFmt, $1)):5:7:8 with errorlines title "whackamole" lt rgb "orange", \
	'' using (strftime(myTimeFmt, $1)):4 axis x1y2 with linespoints title "whackamole success rate" lt rgb "orange"
```

